### PR TITLE
Use refresh token method instead of cookie method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,11 @@
       "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
+    },
     "ts-protoc-gen": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "google-protobuf": "^3.10.0",
     "node-fetch": "^2.6.0",
+    "querystring": "^0.2.1",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a WIP – I assume instead of replacing the old method we'd want to support both. But wanted to leave this PR here.

Adapted from https://github.com/chrisjshull/homebridge-nest/pull/394 ([docs](https://github.com/chrisjshull/homebridge-nest#using-a-google-account---refresh-token-method))